### PR TITLE
semi-colon removed. 

### DIFF
--- a/micro-jpeg-visualizer.py
+++ b/micro-jpeg-visualizer.py
@@ -216,7 +216,7 @@ class jpeg:
 	def BaselineDCT(self, data):
 		hdr, self.height, self.width, components = unpack(">BHHB",data[0:6])
 		print("size %ix%i" % (self.width,  self.height))
-		self.image = [0] * (self.width * self.height);
+		self.image = [0] * (self.width * self.height)
 
 		for i in range(components):
 			id, samp, QtbId = unpack("BBB",data[6+i*3:9+i*3])


### PR DESCRIPTION
Python does not require semi-colons to terminate statements. 